### PR TITLE
Added revoke_access to the Core User Module

### DIFF
--- a/lib/mercadolibre/core/users.rb
+++ b/lib/mercadolibre/core/users.rb
@@ -24,6 +24,13 @@ module Mercadolibre
 
         results[:body].map { |r| Mercadolibre::Entity::PaymentMethod.new(r) }
       end
+
+      def revoke_access(user_id)
+        headers = { content_type: :json, accept: :json }
+        results = delete_request("/users/#{user_id}/applications/#{@app_key}?access_token=#{@access_token}", headers)
+
+        results[:body]
+      end
     end
   end
 end


### PR DESCRIPTION
Added the revoke_access method to the User module. This will unsubscribe a **seller** (through the `user_id`) on the Mercadolibre application (through the `app_key`), to avoid further notifications of that particular **seller**
