### PR TITLE
Added the generate_access_token method to the Auth Core class

### DIFF
--- a/lib/mercadolibre/core/auth.rb
+++ b/lib/mercadolibre/core/auth.rb
@@ -29,6 +29,22 @@ module Mercadolibre
         })
       end
 
+      def generate_access_token
+        response = post_request('/oauth/token', {
+          grant_type: 'client_credentials',
+          client_id: @app_key,
+          client_secret: @app_secret
+        })[:body]
+
+        @access_token = response['access_token']
+
+        Mercadolibre::Entity::Auth.new({
+          access_token: @access_token,
+          refresh_token: response['refresh_token'],
+          expired_at: response['expires_in'].to_i.seconds.from_now
+        })
+      end
+
       def update_token(refresh_token)
         response = post_request('/oauth/token', {
           grant_type: 'refresh_token',

--- a/lib/mercadolibre/core/categories_and_listings.rb
+++ b/lib/mercadolibre/core/categories_and_listings.rb
@@ -53,6 +53,13 @@ module Mercadolibre
 
         Mercadolibre::Entity::Category.new(result[:body])
       end
+
+      def predict_category(site_id, product_title)
+
+        result = get_request("/sites/#{site_id}/category_predictor/predict", { title: product_title })
+
+        result[:body]
+      end
     end
   end
 end

--- a/lib/mercadolibre/core/items_and_searches.rb
+++ b/lib/mercadolibre/core/items_and_searches.rb
@@ -193,6 +193,14 @@ module Mercadolibre
         put_request("/items/#{item_id}?access_token=#{@access_token}", payload, headers)[:body]
       end
 
+      def update_variations_fields(item_id, variation_id, attribs)
+        payload = attribs.to_json
+
+        headers = { content_type: :json, accept: :json }
+
+        put_request("/items/#{item_id}/variations/#{variation_id}?access_token=#{@access_token}", payload, headers)[:body]
+      end
+
       def update_item_listing_type(item_id, listing_type_id)
         payload = { id: listing_type_id }.to_json
 


### PR DESCRIPTION
Adding a new method for `Mercadolibre::Core::Auth` to generate new `access_token` with the app credentials
